### PR TITLE
Wrap promise resolutions in runloops. Avoids auto-runs

### DIFF
--- a/app/components/linkedin-share.js
+++ b/app/components/linkedin-share.js
@@ -8,7 +8,7 @@ function loadLinkedin() {
   if (!linkedinScriptPromise) {
     linkedinScriptPromise = new Ember.RSVP.Promise(function(resolve/*, reject*/) {
       Ember.$.getScript("//platform.linkedin.com/in.js?async=true", function success() {
-        IN.Event.on(IN, 'systemReady', resolve);
+        IN.Event.on(IN, 'systemReady', Ember.run.bind(null, resolve));
         IN.init();
       });
     });

--- a/app/components/twitter-share.js
+++ b/app/components/twitter-share.js
@@ -17,7 +17,9 @@ function loadTwitter() {
       }(document, "script", "twitter-wjs"));
 
       twttr.ready(function(twttr) {
-        resolve(twttr);
+        Ember.run(function(){
+          resolve(twttr);
+        });
       });
     });
   }

--- a/app/services/facebook-loader.js
+++ b/app/services/facebook-loader.js
@@ -31,7 +31,9 @@ export default Ember.Object.extend({
             xfbml      : true,
             version    : 'v2.1'
           });
-          resolve(FB);
+          Ember.run(function(){
+            resolve(FB);
+          });
         };
 
         (function(d, s, id){


### PR DESCRIPTION
Hm, PR #4 is _almost_ as neat as having PR #1.

The resolve callback of a promise should be wrapped in a runloop. If not, it causes an auto-run.

:-D Fun stuff!
