### PR TITLE
Added Twitter Embedded Tweet component with Bower Fix

### DIFF
--- a/app/components/twitter-card.js
+++ b/app/components/twitter-card.js
@@ -1,0 +1,42 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  socialApiClient: null, // injected
+
+  "tweet-id": null, // required - id of the tweet that you want to embed
+  cards: null, // When set to hidden, links in a Tweet are not expanded to photo, video, or link previews.
+  conversation: null, // When set to none, only the cited Tweet will be displayed even if it is in reply to another Tweet.
+  lang: null, // A supported Twitter language code. https://dev.twitter.com/overview/general/adding-international-support-to-your-apps,
+  dnt: null, // When set to true, the Tweet and its embedded page do not influence Twitter targeting including suggested accounts. https://support.twitter.com/articles/20169421,
+  theme: null, // When set to dark, displays Tweet with light text over a dark background.
+  "link-color": null, // Adjust the color of Tweet links with a hexadecimal color value.
+  width: null, // The maximum width of the rendered Tweet in whole pixels. This value should be between 250 and 550 pixels.
+  align: null, // Float the Tweet left, right, or center relative to its container.
+
+  loadTwitterClient: function() {
+    var self = this;
+    this.socialApiClient.load().then(function(twttr) {
+      if (self._state !== 'inDOM') { return; }
+      self.twttr = twttr;
+      self.trigger('twitterLoaded');
+    });
+  }.on('didInsertElement'),
+
+  createTwitterCard: function() {
+    var tweetId = this.get('tweet-id');
+    if (tweetId) {
+      this.twttr.widgets.createTweet(tweetId, this.get('element'), {
+        cards: this.get('cards'),
+        conversation: this.get('conversation'),
+        lang: this.get('lang'),
+        dnt: this.get('dnt'),
+        theme: this.get('theme'),
+        linkColor: this.get('link-color'),
+        width: this.get('width'),
+        align: this.get('align')
+      }).then(function (/*el*/) {
+        Ember.Logger.debug('Twitter Tweet Embed created.');
+      });
+    }
+  }.on('twitterLoaded')
+});

--- a/app/components/twitter-card.js
+++ b/app/components/twitter-card.js
@@ -4,7 +4,7 @@ export default Ember.Component.extend({
   socialApiClient: null, // injected
 
   "tweet-id": null, // required - id of the tweet that you want to embed
-  cards: null, // When set to hidden, links in a Tweet are not expanded to photo, video, or link previews.
+  cards: "hidden", // When set to hidden, links in a Tweet are not expanded to photo, video, or link previews.
   conversation: null, // When set to none, only the cited Tweet will be displayed even if it is in reply to another Tweet.
   lang: null, // A supported Twitter language code. https://dev.twitter.com/overview/general/adding-international-support-to-your-apps,
   dnt: null, // When set to true, the Tweet and its embedded page do not influence Twitter targeting including suggested accounts. https://support.twitter.com/articles/20169421,
@@ -35,7 +35,7 @@ export default Ember.Component.extend({
         width: this.get('width'),
         align: this.get('align')
       }).then(function (/*el*/) {
-        Ember.Logger.debug('Twitter Tweet Embed created.');
+        Ember.Logger.debug('Twitter Embedded Tweet inserted.');
       });
     }
   }.on('twitterLoaded')

--- a/app/initializers/ember-social-services.js
+++ b/app/initializers/ember-social-services.js
@@ -10,5 +10,7 @@ export default {
     application.inject('component:twitter-share', 'socialApiClient', 'service:twitter-api-client');
 
     application.inject('component:linkedin-share', 'socialApiClient', 'service:linkedin-api-client');
+
+    application.inject('component:twitter-card', 'socialApiClient', 'service:twitter-api-client');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -13,5 +13,9 @@
     "ember-qunit": "0.1.8",
     "ember-qunit-notifications": "0.0.4",
     "qunit": "~1.15.0"
+  },
+  "resolutions": {
+    "ember": "1.7.0",
+    "handlebars": "~1.3.0"
   }
 }

--- a/tests/acceptance/twitter-test.js
+++ b/tests/acceptance/twitter-test.js
@@ -36,3 +36,15 @@ test('share', function() {
     }, 2500);
   });
 });
+
+test('tweet', function(){
+  visit('/twitter/card');
+
+  andThen(function(){
+    equal(currentPath(), 'twitter.card');
+
+    Ember.run.later(function(){
+      equal(find('.twitter-tweet').length, 2, 'Two twitter tweets were rendered.');
+    }, 2500);
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
   });
   this.resource('twitter', function() {
     this.route('share');
+    this.route('card');
   });
   this.resource('linkedin', function() {
     this.route('share');

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -14,6 +14,7 @@
     <h3>Twitter</h3>
     <ul>
       <li>{{#link-to "twitter.share"}}Twitter Share{{/link-to}}</li>
+      <li>{{#link-to "twitter.card"}}Twitter Card{{/link-to}}</li>
     </ul>
   </div>
 

--- a/tests/dummy/app/templates/twitter/card.hbs
+++ b/tests/dummy/app/templates/twitter/card.hbs
@@ -1,3 +1,21 @@
-<h1>Twitter Tweet Embed</h1>
+<h1>Twitter Embedded Tweets</h1>
 
-{{twitter-card tweet-id="537294958378905600"}}
+<h2>Basic Card</h2>
+
+You have to specify tweet-id parameter to embed a card. The default card does not show photos or videos.
+
+<code>
+  \{{twitter-card tweet-id="463440424141459456"}}
+</code>
+
+{{twitter-card tweet-id="463440424141459456"}}
+
+<h2>Card with Media</h2>
+
+To display media, set <strong>cards</strong> parameter to false.
+
+{{twitter-card tweet-id="463440424141459456" cards=null}}
+
+<code>
+  \{{twitter-card tweet-id="463440424141459456" cards=false}}
+</code>

--- a/tests/dummy/app/templates/twitter/card.hbs
+++ b/tests/dummy/app/templates/twitter/card.hbs
@@ -1,0 +1,3 @@
+<h1>Twitter Tweet Embed</h1>
+
+{{twitter-card tweet-id="537294958378905600"}}


### PR DESCRIPTION
This PR adds a component that allows to embed Twitter cards with ```{{twitter-card tweet-id=<tweet_id>}}```.

Includes: 

* twitter-card component
* twitter/card page with code example
* acceptance test for twitter-card component

This PR was rebased on PR #9 and supersedes PR #8 