### PR TITLE
Makes twttr global variable play nice if it's already loaded.

### DIFF
--- a/app/services/twitter-api-client.js
+++ b/app/services/twitter-api-client.js
@@ -13,13 +13,21 @@ export default Ember.Object.extend({
     var self = this;
     if (!twitterScriptPromise) {
       twitterScriptPromise = new Ember.RSVP.Promise(function(resolve, reject) {
-        window.twttr = (function (d, s, id) {
-          var t, js, fjs = d.getElementsByTagName(s)[0];
+        window.twttr = (function(d, s, id) {
+          var js, fjs = d.getElementsByTagName(s)[0],
+            t = window.twttr || {};
           if (d.getElementById(id)) return;
-          js = d.createElement(s); js.id = id;
-          js.src= "https://platform.twitter.com/widgets.js";
+          js = d.createElement(s);
+          js.id = id;
+          js.src = "https://platform.twitter.com/widgets.js";
           fjs.parentNode.insertBefore(js, fjs);
-          return window.twttr || (t = { _e: [], ready: function (f) { t._e.push(f) } });
+
+          t._e = [];
+          t.ready = function(f) {
+            t._e.push(f);
+          };
+
+          return t;
         }(document, "script", "twitter-wjs"));
 
         twttr.ready(function(twttr) {


### PR DESCRIPTION
* Before this change, if your application happened to load Twitter's
  [conversion tracking script](https://platform.twitter.com/oct.js), an
  error would be thrown because that script doesn't define twttr.ready
  which is a function this addon relies on.