### PR TITLE
Install PhantomJS 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ before_install:
   - "npm install -g npm@^2"
 
 install:
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
   - npm install -g bower
   - npm install
   - bower install


### PR DESCRIPTION
Acceptance tests once again pass on PhantomJS 2.0.

#### Installing PhantomJS 2.0

PhantomJS 2.0 isn't fully out the door. Linux binaries aren't available from their site. Travis is hosting a 2.0 binary they built from source.

- https://github.com/Medium/phantomjs/issues/288
- https://github.com/travis-ci/travis-ci/issues/3225
- https://github.com/ariya/phantomjs/issues/12948

**Installing on OS X**
```
npm uninstall -g phantomjs
bower install phantomjs
```

#### Working Theory

Twitter tests that had previously passed began to fail on PhantomJS 1.9.8 (and 1.9.7 I believe). I saw additional test failures locally on PhantomJS 1.9.7 as well. 

My unsubstantiated suspicion is that earlier versions of Phantom were defaulting to an SSL protocol for which Twitter [killed support](http://mashable.com/2014/10/15/twitter-kills-ssl-3-support/) in the wake of [POODLE](http://en.wikipedia.org/wiki/POODLE). The problem is that [`twttr.ready` never fires](https://github.com/plyfe/ember-social/blob/97970fe0ab275da2fb29368d8cd5536ce9bcd6b2/app/services/twitter-api-client.js#L33), leading me to believe that the [Twitter widgets.js script](https://platform.twitter.com/widgets.js) simply isn't arriving.

#### PhantomJS Config Differences, 1.9.8 vs 2.0.0
https://gist.github.com/chrislopresto/426d617198c232469418#file-phantomjs_poodling-sh-L27

```
ember-social › phantomjs -v
1.9.8

ember-social › phantomjs -h
  ...
  --ssl-protocol=<val>                 Sets the SSL protocol (supported protocols: 'SSLv3', 'SSLv2', 'TLSv1' (default), 'any')
  ...

ember-social › phantomjs -v
2.0.0

ember-social › phantomjs -h
  ...
  --ssl-protocol=<val>                 Selects a specific SSL protocol version to offer. Values (case insensitive): TLSv1.2, TLSv1.1, TLSv1.0, TLSv1 (same as v1.0), SSLv3, or ANY. Default is to offer all that Qt thinks are secure (SSLv3 and up). Not all values may be supported, depending on the system OpenSSL library.
  ...
```