### PR TITLE
dependency issues and changes to rimraf not allowing dummy app to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "engines": {
     "node": ">= 0.10.0"
   },
+  "dependencies": {
+    "rimraf": "2.2.8"
+  },
   "author": "",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Hi, I was getting an error in broccoli:

TypeError: Object function glob(pattern, options, cb) {...} has no method 'hasMagic'

and was unable to run "ember server" to see the sample application

This was because the latest version of rimraf required glob @'^4.4.2' but your dependencies file specifies     "glob": "^4.0.5"

this update specifies a compatible version of rimraf