### PR TITLE
Allow passing in appId to facebook components

### DIFF
--- a/addon/components/facebook-facepile.js
+++ b/addon/components/facebook-facepile.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import LoadWithOptionsMixin from 'ember-social/mixins/load-with-options';
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(LoadWithOptionsMixin, {
   socialApiClient: null, //injected
 
   url: null, // Defaults to specified Facebook app_id
@@ -8,7 +9,7 @@ export default Ember.Component.extend({
 
   createFacebookFacepile: Ember.on('didInsertElement', function() {
     var self = this;
-    this.socialApiClient.load().then(function(FB) {
+    this.loadSocialApiClient().then(function(FB) {
       if (self._state !== 'inDOM') { return; }
       var attrs = [];
       var url = self.get('url');

--- a/addon/components/facebook-like.js
+++ b/addon/components/facebook-like.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+import LoadWithOptionsMixin from 'ember-social/mixins/load-with-options';
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(LoadWithOptionsMixin, {
   socialApiClient: null, // injected
 
   url: null, // Defaults to current url
@@ -9,7 +10,7 @@ export default Ember.Component.extend({
 
   createFacebookLikeButton: Ember.on('didInsertElement', function() {
     var self = this;
-    this.socialApiClient.load().then(function(FB) {
+    this.loadSocialApiClient().then(function(FB) {
       if (self._state !== 'inDOM') { return; }
       var attrs = [];
       var url = self.get('url');

--- a/addon/components/facebook-share.js
+++ b/addon/components/facebook-share.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import LoadWithOptionsMixin from 'ember-social/mixins/load-with-options';
 
 /*
  * Show a button that pops up the Facebook Share dialog.
@@ -8,7 +9,7 @@ import Ember from 'ember';
  * tracking object. When using without specifying a tagName, click
  * tracking is not supported due to restrictions of the Facebook SDK.
  */
-export default Ember.Component.extend({
+export default Ember.Component.extend(LoadWithOptionsMixin, {
   socialApiClient: null, // injected
 
   tagName: 'div', // set tagName to 'a' in handlebars to use your own css/content
@@ -21,7 +22,7 @@ export default Ember.Component.extend({
 
   createFacebookShareButton: Ember.on('didInsertElement', function() {
     var self = this;
-    this.socialApiClient.load().then(function(FB) {
+    this.loadSocialApiClient().then(function(FB) {
       self.FB = FB;
       if (self._state !== 'inDOM') { return; }
       if (self.get('useFacebookUi')) {

--- a/addon/mixins/load-with-options.js
+++ b/addon/mixins/load-with-options.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+// Mixin used for components where appId can be passed in to load api client
+export default Ember.Mixin.create({
+  appId: null, // optional
+  loadOptions: Ember.computed('appId', function() {
+    return {
+      appId: this.get('appId')
+    };
+  }),
+  loadSocialApiClient: function() {
+    return this.get('socialApiClient').load(this.get('loadOptions'));
+  },
+});


### PR DESCRIPTION
@chrislopresto @lukemelia thoughts on this pattern?

Question:
If there are several facebook components in an app and only some of them are passed an `appId`, the ones that aren't will use the default appId from env, metatag, or global. Do we want `load` to return a new promise if the `appId` changes between components calling `load()`? (ie: as implemented in this PR with `currentIdIsUpdated`)
