### PR TITLE
Twitter share missing options

### DIFF
--- a/addon/components/twitter-share.js
+++ b/addon/components/twitter-share.js
@@ -54,7 +54,10 @@ export default Ember.Component.extend({
       this.get('element'),
       {
         count: this.get('count'),
-        text: this.get('text')
+        text: this.get('text'),
+        via: this.get('via'),
+        hashtags: this.get('hashtags'),
+        related: this.get('related')
       }).then(function (/*el*/) {
         Ember.Logger.debug('Twitter Share Button created.');
       }

--- a/tests/dummy/app/templates/twitter/share.hbs
+++ b/tests/dummy/app/templates/twitter/share.hbs
@@ -12,7 +12,6 @@
   {{twitter-share}}
 </div>
 
-
 <h2>Custom URL and Text</h2>
 
 <p>Specified url and text attributes. Shares specified url and specified text via standard Twitter UI share button.</p>
@@ -63,7 +62,7 @@
     hashtags='tweet,factory'
     url='http://example.com/share-things'
     text="Help, I'm stuck in a tweet factory."}}
-    Tweet this article
+    Tweet this articlehttps://twitter.com/iamdevloper
   \{{/twitter-share}}
 </code>
 
@@ -78,3 +77,28 @@
     Tweet this article
   {{/twitter-share}}
 </div>
+
+<h2>Via</h2>
+
+<p>Attribute the source of a Tweet to a Twitter username using the via parameter. The attribution will appear in a Tweet as ” via @username” translated into the language of the Tweet author.</p>
+
+<code>
+  \{{twitter-share via='emberjs'}}
+</code>
+
+<h2>Hashtags</h2>
+
+<p>Add a comma-separated list of hashtags to a Tweet using the hashtags parameter. Omit a preceding “#” from each hashtag; the Tweet composer will automatically add the proper space-separated hashtag by language.</p>
+
+<code>
+  \{{twitter-share hashtags="ember,javascript"}}
+</code>
+
+<h2>Related</h2>
+
+<p>Twitter may suggest accounts to follow after the author has successfully posted a Tweet. These displayed accounts are influenced by the via and related 
+web intent parameters.</p>
+
+<code>
+  \{{twitter-share related="emberjs,plyfe"}}
+</code>


### PR DESCRIPTION
This allows twitter share to pass on the via, hashtags and related options.