### PR TITLE
fixed twitter share button inconsistency 

### DIFF
--- a/addon/services/twitter-api-client.js
+++ b/addon/services/twitter-api-client.js
@@ -18,7 +18,7 @@ export default Ember.Object.extend({
         window.twttr = (function(d, s, id) {
           var js, fjs = d.getElementsByTagName(s)[0],
             t = window.twttr || {};
-          if (d.getElementById(id)) {return;}
+          if (d.getElementById(id)) { return window.twttr; }
           js = d.createElement(s);
           js.id = id;
           js.src = "https://platform.twitter.com/widgets.js";


### PR DESCRIPTION
fixed twitter share button when first page loaded is not the one with the component.
 - added a returning value to twttr variable when it detects script tag already inserted into the page

When the first page loaded of your application is not the one with twitter widget and then you go to the page with the component, it shows up an error on console and dont render the component