### PR TITLE
Prevent deprecation for initializer

### DIFF
--- a/addon/initializers/ember-social-services.js
+++ b/addon/initializers/ember-social-services.js
@@ -1,6 +1,6 @@
 export default {
   name: 'ember-social-services',
-  initialize: function(container, application){
+  initialize: function(application){
     var facebookPluginComponents = ['facepile', 'like', 'share'];
 
     facebookPluginComponents.forEach(function(plugin) {

--- a/addon/services/facebook-api-client.js
+++ b/addon/services/facebook-api-client.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 
 var facebookScriptPromise;
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
   /*
    * A tracking object implementing `shared(serviceName, payload)` and/or
    * `clicked(serviceName, payload)` can be set on this object, and will

--- a/addon/services/linkedin-api-client.js
+++ b/addon/services/linkedin-api-client.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 
 var linkedinScriptPromise;
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
   /*
    * A tracking object implementing `shared(serviceName, payload)` and/or
    * `clicked(serviceName, payload)` can be set on this object, and will

--- a/addon/services/twitter-api-client.js
+++ b/addon/services/twitter-api-client.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 
 var twitterScriptPromise;
 
-export default Ember.Object.extend({
+export default Ember.Service.extend({
   /*
    * A tracking object implementing `shared(serviceName, payload)` and/or
    * `clicked(serviceName, payload)` can be set on this object, and will


### PR DESCRIPTION
Was previously getting a deprecation warning in the console for including container in the initializer.  
See this portion of the docs for more details: http://emberjs.com/deprecations/v2.x/#toc_initializer-arity