### PR TITLE
Fix bug with unresolved load promise when Facebook SDK already loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,27 @@ As an 'a' tag:
 
 `{{facebook-share fb-colorscheme='dark'}}`
 
+##### Loading the Facebook SDK
+
+The addon will load the Facebook SDK for you when needed. However, if your app or another addon in your project also requires the SDK, you should consider loading it yourself to avoid conflicts.
+You can pass a promise that resolves with the initialized `FB` object by overriding the `facebookSDK` property.
+
+You can pass the promise to the component directly.
+
+`{{facebook-share facebookSDK=<insert a promise that resolves with the FB object>}}`
+
+This can get tedious if you're using many buttons. In that case, you can override the property by extending the `facebook-api-client` service.
+
+```javascript
+import FacebookApiClientService from 'ember-social/services/facebook-api-client';
+
+export default FacebookApiClientService.extend({
+
+  facebookSDK: /* <insert a promise that resolves with the FB object> */,
+
+});
+```
+
 ### Twitter
 
 #### Share

--- a/addon/components/facebook-like.js
+++ b/addon/components/facebook-like.js
@@ -4,6 +4,7 @@ export default Ember.Component.extend({
   socialApiClient: Ember.inject.service('facebook-api-client'), // injected
 
   url: null, // Defaults to current url
+  facebookSDK: null,
   'fb-layout': 'standard', // Valid options: 'standard', 'button_count', 'button', or 'box_count'
   'fb-action': 'like', // Valid options: 'like' or 'recommend'
   'fb-show-faces': 'true',
@@ -12,6 +13,9 @@ export default Ember.Component.extend({
   'fb-width': null,
 
   createFacebookLikeButton: Ember.on('didInsertElement', function() {
+    var facebookSDK = this.get('facebookSDK');
+    if (facebookSDK) { this.set('socialApiClient.facebookSDK', facebookSDK); }
+
     var self = this;
     this.get('socialApiClient').load().then(function(FB) {
       if (self._state !== 'inDOM') { return; }

--- a/addon/components/facebook-share.js
+++ b/addon/components/facebook-share.js
@@ -17,9 +17,13 @@ export default Ember.Component.extend({
   useFacebookUi: Ember.computed.not('isCustomLink'),
 
   url: null, // Defaults to current url
+  facebookSDK: null,
   "fb-layout": "icon_link", // Valid options: "box_count", "button_count", "button", "link", "icon_link", or "icon"
 
   createFacebookShareButton: Ember.on('didInsertElement', function() {
+    var facebookSDK = this.get('facebookSDK');
+    if (facebookSDK) { this.set('socialApiClient.facebookSDK', facebookSDK); }
+
     var self = this;
     this.get('socialApiClient').load().then(function(FB) {
       self.FB = FB;

--- a/addon/services/facebook-api-client.js
+++ b/addon/services/facebook-api-client.js
@@ -2,9 +2,14 @@ import Ember from 'ember';
 
 /* globals FB */
 
-var facebookScriptPromise;
-
 export default Ember.Service.extend({
+  /**
+   * A promise which resolves with the initialized FB object. This is either
+   * set on initial load or can be overriden by the user to bring-their-own
+   * SDK.
+   */
+  facebookSDK: null,
+
   /*
    * A tracking object implementing `shared(serviceName, payload)` and/or
    * `clicked(serviceName, payload)` can be set on this object, and will
@@ -27,33 +32,36 @@ export default Ember.Service.extend({
   },
 
   load: function() {
-    var self = this;
-    if (!facebookScriptPromise) {
-      facebookScriptPromise = new Ember.RSVP.Promise(function(resolve/*, reject*/) {
-        if (Ember.$('#fb-root').length === 0) {
-          Ember.$('body').append('<div id="fb-root"></div>');
-        }
-        window.fbAsyncInit = function() {
-          FB.init({
-            appId      : self.appId(),
-            xfbml      : true,
-            version    : 'v2.1'
-          });
-          Ember.run(function(){
-            resolve(FB);
-          });
-        };
+    var facebookSDK = this.get('facebookSDK');
+    if (facebookSDK) { return facebookSDK; }
 
-        (function(d, s, id){
-           var js, fjs = d.getElementsByTagName(s)[0];
-           if (d.getElementById(id)) {return;}
-           js = d.createElement(s); js.id = id;
-           js.src = "//connect.facebook.net/en_US/sdk.js";
-           fjs.parentNode.insertBefore(js, fjs);
-         }(document, 'script', 'facebook-jssdk'));
-      });
-    }
-    return facebookScriptPromise;
+    Ember.assert('The Facebook SDK has already been loaded. It is likely that another addon has already initialized the SDK with its own settings, which may lead to conflicts. For more information see: https://github.com/plyfe/ember-social#loading-the-facebook-sdk', !window.FB);
+
+    var self = this;
+    var facebookScriptPromise = new Ember.RSVP.Promise(function(resolve/*, reject*/) {
+      if (Ember.$('#fb-root').length === 0) {
+        Ember.$('body').append('<div id="fb-root"></div>');
+      }
+      window.fbAsyncInit = function() {
+        FB.init({
+          appId      : self.appId(),
+          xfbml      : true,
+          version    : 'v2.1'
+        });
+        Ember.run(function(){
+          resolve(FB);
+        });
+      };
+
+      (function(d, s, id){
+         var js, fjs = d.getElementsByTagName(s)[0];
+         if (d.getElementById(id)) {return;}
+         js = d.createElement(s); js.id = id;
+         js.src = "//connect.facebook.net/en_US/sdk.js";
+         fjs.parentNode.insertBefore(js, fjs);
+       }(document, 'script', 'facebook-jssdk'));
+    });
+    return this.set('facebookSDK', facebookScriptPromise);
   },
 
   clicked: function(payload) {

--- a/tests/acceptance/facebook-test.js
+++ b/tests/acceptance/facebook-test.js
@@ -1,8 +1,21 @@
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import startApp from '../../tests/helpers/start-app';
 import Ember from 'ember';
 
-moduleForAcceptance('Acceptance | facebook');
+moduleForAcceptance('Acceptance | facebook', {
+  beforeEach: function() {
+    this.application = startApp();
+    if (window.FB) {
+      // Acceptance testing creates an unrealistic scenario where the app is
+      // reloaded between tests without reloading the page and reseting the
+      // window object. After initially loading the SDK, stub FB in the service
+      // with the loaded SDK.
+      var facebookAPI = this.application.__container__.lookup('service:facebook-api-client');
+      facebookAPI.set('facebookSDK', Ember.RSVP.resolve(window.FB));
+    }
+  }
+});
 
 test('share', function(assert) {
   visit('/facebook/share');
@@ -18,7 +31,8 @@ test('share', function(assert) {
       'layout-button-count',
       'layout-button',
       'layout-link',
-      'layout-icon'
+      'layout-icon',
+      'custom-load-sdk'
     ];
 
     Ember.run.later(function() {
@@ -44,7 +58,8 @@ test('like', function(assert) {
       'layout-standard',
       'layout-button-count',
       'layout-button',
-      'layout-box-count'
+      'layout-box-count',
+      'custom-load-sdk'
     ];
 
     Ember.run.later(function() {

--- a/tests/dummy/app/controllers/tracking.js
+++ b/tests/dummy/app/controllers/tracking.js
@@ -1,2 +1,7 @@
 import Ember from 'ember';
-export default Ember.Controller.extend({});
+export default Ember.Controller.extend({
+  facebookAPIClient: Ember.inject.service('facebook-api-client'),
+  facebookSDK: Ember.computed('', function() {
+    return this.get('facebookAPIClient').load();
+  })
+});

--- a/tests/dummy/app/templates/facebook/like.hbs
+++ b/tests/dummy/app/templates/facebook/like.hbs
@@ -69,3 +69,14 @@
 <div id='layout-box-count'>
   {{facebook-like fb-layout='box_count'}}
 </div>
+
+<h2>Loading the Facebook SDK yourself</h2>
+
+<code>
+  \{{facebook-like facebookSDK=/*a promise that resolves with the FB object*/}}
+</code>
+
+<div id='custom-load-sdk'>
+  {{facebook-like facebookSDK=facebookSDK}}
+</div>
+

--- a/tests/dummy/app/templates/facebook/share.hbs
+++ b/tests/dummy/app/templates/facebook/share.hbs
@@ -91,3 +91,12 @@
   {{/facebook-share}}
 </div>
 
+<h2>Load the Facebook SDK yourself</h2>
+
+<code>
+  \{{facebook-like facebookSDK=/*a promise that resolves with the FB object*/}}
+</code>
+
+<div id='custom-load-sdk'>
+  {{facebook-like facebookSDK=facebookSDK}}
+</div>

--- a/tests/unit/services/addon/services/facebook-api-client.js-test.js
+++ b/tests/unit/services/addon/services/facebook-api-client.js-test.js
@@ -1,0 +1,46 @@
+import { moduleFor, test } from 'ember-qunit';
+import Ember from 'ember';
+
+moduleFor('service:facebook-api-client', 'Unit | Service | FacebookApiClient', {
+  unit: true,
+  beforeEach: function() {
+    window.FB = undefined;
+    window.fbAsyncInit = undefined;
+    Ember.$('#facebook-jssdk').remove();
+  }
+});
+
+test('it loads and initializes the Facebook SDK', function(assert) {
+  var done = assert.async();
+
+  var service = this.subject();
+  service.load().then((FB) => {
+    assert.ok(FB, 'Loads and returns the SDK');
+    assert.ok(window.fbAsyncInit.hasRun, 'Initializes the SDK');
+    done();
+  });
+});
+
+test('it throws an error when the Facebook SDK has already been loaded externally', function(assert) {
+  assert.expect(1);
+  window.FB = true;
+  window.fbAsyncInit = { hasRun: true };
+
+  var service = this.subject();
+  assert.throws(function() {
+    service.load();
+  }, /The Facebook SDK has already been loaded/);
+});
+
+test('it returns the FB object when the facebookSDK attribute is set', function(assert) {
+  var done = assert.async();
+  window.FB = true;
+  window.fbAsyncInit = { hasRun: true };
+
+  var service = this.subject();
+  service.set('facebookSDK', Ember.RSVP.resolve('SDK'));
+  service.load().then((FB) => {
+    assert.equal(FB, 'SDK', 'Returns the SDK');
+    done();
+  });
+});


### PR DESCRIPTION
Fixes #51

- Implement an assertion to warn developers when the SDK has already been
  loaded by some external source, e.g. another addon.

- Implement a method of passing a promise which resolves with the FB object via
  the facebookSDK attribute. Allow developers to bring-their-own SDK per
  component and allow to override globally.