### PR TITLE
Update ember-cli-babel version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "linkedin"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.3",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-htmlbars": "^1.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: evedresses-ecommerce -> ember-social -> ember-cli-babel
